### PR TITLE
Allow clients to supply options to mubsub

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,7 +63,8 @@ function adapter(uri, opts) {
 	var key = opts.key || 'socket.io';
 
 	// init clients if needed
-	if (!client) client = socket ? mubsub(socket) : mubsub('mongodb://' + creds + host + ':' + port + '/' + db);
+	var uri = 'mongodb://' + creds + host + ':' + port + '/' + db
+	if (!client) client = socket ? mubsub(socket) : mubsub(uri, opts);
 
 	// this server's key
 	var uid = uid2(6);


### PR DESCRIPTION
Allows a client to supply the options object to the mubsub Connection api.

We needed full access to the Connection interface here: https://github.com/scttnlsn/mubsub/blob/master/lib/connection.js#L13